### PR TITLE
feat(ci): add npm publish pipeline with release-please

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -1,1 +1,21 @@
-{}
+{
+  "bump-minor-pre-major": true,
+  "bump-patch-for-minor-pre-major": true,
+  "packages": {
+    "packages/corespec": {
+      "release-type": "node",
+      "package-name": "@getcorespec/corespec",
+      "changelog-path": "CHANGELOG.md"
+    },
+    "packages/specguard": {
+      "release-type": "node",
+      "package-name": "@getcorespec/specguard",
+      "changelog-path": "CHANGELOG.md"
+    },
+    "packages/respec": {
+      "release-type": "node",
+      "package-name": "@getcorespec/respec",
+      "changelog-path": "CHANGELOG.md"
+    }
+  }
+}

--- a/.github/release-please-manifest.json
+++ b/.github/release-please-manifest.json
@@ -1,1 +1,5 @@
-{}
+{
+  "packages/corespec": "0.0.1",
+  "packages/specguard": "0.0.1",
+  "packages/respec": "0.0.1"
+}

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -5,6 +5,11 @@ on:
     branches: [main]
   pull_request:
 
+permissions:
+  contents: write
+  pull-requests: write
+  actions: write
+
 jobs:
   build-and-test:
     runs-on: ubuntu-latest
@@ -23,3 +28,32 @@ jobs:
       - run: pnpm -r build
 
       - run: pnpm -r test
+
+  check-release:
+    needs: [build-and-test]
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    outputs:
+      released: ${{ steps.release-please.outputs.releases_created }}
+      tag: ${{ steps.release-please.outputs.tag_name }}
+      rp_outputs: ${{ toJSON(steps.release-please.outputs) }}
+    steps:
+      - uses: googleapis/release-please-action@v4
+        id: release-please
+        with:
+          config-file: .github/release-please-config.json
+          manifest-file: .github/release-please-manifest.json
+
+  trigger-release:
+    needs: [check-release]
+    if: needs.check-release.outputs.released == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Trigger release workflow
+        run: |
+          gh workflow run release.yaml \
+            --field tag="${{ needs.check-release.outputs.tag }}"
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,1 +1,37 @@
 name: release
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Git tag to release (e.g. "@getcorespec/specguard-v0.1.0")'
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  publish-npm:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.tag }}
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+          registry-url: https://registry.npmjs.org
+
+      - run: pnpm install --frozen-lockfile
+
+      - run: pnpm -r build
+
+      - name: Publish packages
+        run: pnpm -r publish --access public --no-git-checks
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/docs/plans/2026-03-02-npm-publish-pipeline-design.md
+++ b/docs/plans/2026-03-02-npm-publish-pipeline-design.md
@@ -1,0 +1,44 @@
+# npm Publish Pipeline Design
+
+## Overview
+
+Automated npm publishing for all `@getcorespec` packages using release-please and GitHub Actions.
+
+## Architecture
+
+Two workflows:
+
+- **cicd.yaml** — build, test, then run release-please on main. If a release is created, triggers the release workflow.
+- **release.yaml** — `workflow_dispatch` that checks out a git tag and publishes to npm. Can be triggered automatically by cicd or manually.
+
+## Flow
+
+```
+PR → build-and-test
+Main push → build-and-test → check-release (release-please) → trigger-release
+                                                                     ↓
+                                                              release.yaml
+                                                                     ↓
+                                                              pnpm -r publish
+```
+
+## Packages
+
+All three packages are included in the release-please config:
+
+| Package | npm Name | Version |
+|---------|----------|---------|
+| packages/corespec | @getcorespec/corespec | 0.0.1 |
+| packages/specguard | @getcorespec/specguard | 0.0.1 |
+| packages/respec | @getcorespec/respec | 0.0.1 |
+
+## Secrets Required
+
+- `NPM_TOKEN` — npm granular access token scoped to `@getcorespec`
+
+## Decisions
+
+- **Public access** — packages published with `--access public`
+- **All packages included** — even respec (stub), can be excluded later
+- **Separate release workflow** — matches agents-at-scale-ark pattern, allows manual re-runs
+- **bump-minor-pre-major** — while pre-1.0, `feat:` bumps patch not minor


### PR DESCRIPTION
## Summary
- Configure release-please for all three `@getcorespec` packages (multi-package monorepo pattern)
- Extend `cicd.yaml` with `check-release` job gated behind `build-and-test`, triggers release on main
- Add `release.yaml` as `workflow_dispatch` for npm publishing (auto-triggered or manual via git tag)
- Requires `NPM_TOKEN` secret to be configured in repo settings