### PR TITLE
chore: add identity guard, CODEOWNERS, and path redaction

### DIFF
--- a/.claude/hooks/identity-guard.sh
+++ b/.claude/hooks/identity-guard.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+# Block commits, pushes, and gh CLI actions unless identity is gaspodewonder.
+# Also block any content containing /Users/<username>/ paths.
+
+INPUT=$(cat)
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
+
+deny() {
+  cat <<EOF
+{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"$1"}}
+EOF
+  exit 1
+}
+
+allow() {
+  echo '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"allow"}}'
+  exit 0
+}
+
+# Check git identity on commit commands
+if [[ "$COMMAND" =~ git\ commit ]]; then
+  AUTHOR_EMAIL="${GIT_AUTHOR_EMAIL:-$(git config user.email 2>/dev/null)}"
+  if [[ "$AUTHOR_EMAIL" != *"gaspodewonder"* ]]; then
+    deny "Git author email must contain gaspodewonder. Current: $AUTHOR_EMAIL"
+  fi
+fi
+
+# Check gh CLI identity on push/pr commands
+if [[ "$COMMAND" =~ ^gh\ (pr|issue|api|workflow) ]] || [[ "$COMMAND" =~ git\ push ]]; then
+  GH_USER=$(gh auth status 2>&1 | grep "Active account: true" -B1 | head -1 | grep -o 'account [^ ]*' | cut -d' ' -f2)
+  if [[ "$GH_USER" != "gaspodewonder" ]]; then
+    deny "GitHub CLI active account must be gaspodewonder. Current: $GH_USER"
+  fi
+fi
+
+# Block any command that would write /Users/<username>/ paths into files
+if [[ "$COMMAND" =~ /Users/[A-Za-z_]+/ ]] && [[ "$COMMAND" =~ (echo|cat|write|>>|>) ]]; then
+  deny "Command contains a /Users/<username>/ path. Use \$HOME instead."
+fi
+
+allow

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/identity-guard.sh",
+            "timeout": 10000
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @gaspodewonder

--- a/docs/plans/2026-02-28-specguard-phase1.md
+++ b/docs/plans/2026-02-28-specguard-phase1.md
@@ -195,13 +195,13 @@ Used by [@getcorespec/specguard](../specguard/) and [@getcorespec/respec](../res
 **Step 7: Install dependencies**
 
 ```bash
-cd /Users/Dave_Kerr/repos/github/gdog/corespec && pnpm install
+cd $HOME/repos/github/gdog/corespec && pnpm install
 ```
 
 **Step 8: Build and verify**
 
 ```bash
-cd /Users/Dave_Kerr/repos/github/gdog/corespec/packages/corespec && pnpm build
+cd $HOME/repos/github/gdog/corespec/packages/corespec && pnpm build
 ```
 
 Expected: clean compile, no errors.
@@ -315,7 +315,7 @@ describe('checkFramework', () => {
 **Step 2: Run test to verify it fails**
 
 ```bash
-cd /Users/Dave_Kerr/repos/github/gdog/corespec/packages/corespec && pnpm build && pnpm test
+cd $HOME/repos/github/gdog/corespec/packages/corespec && pnpm build && pnpm test
 ```
 
 Expected: FAIL — `checkFramework` not found.
@@ -448,7 +448,7 @@ export { checkFramework } from './tools/check-framework.js';
 **Step 5: Build and run tests**
 
 ```bash
-cd /Users/Dave_Kerr/repos/github/gdog/corespec/packages/corespec && pnpm build && pnpm test
+cd $HOME/repos/github/gdog/corespec/packages/corespec && pnpm build && pnpm test
 ```
 
 Expected: all 6 tests PASS.
@@ -505,7 +505,7 @@ describe('parseModelId', () => {
 **Step 2: Run test to verify it fails**
 
 ```bash
-cd /Users/Dave_Kerr/repos/github/gdog/corespec/packages/corespec && pnpm build && pnpm test
+cd $HOME/repos/github/gdog/corespec/packages/corespec && pnpm build && pnpm test
 ```
 
 Expected: FAIL.
@@ -573,7 +573,7 @@ export { parseModelId, callLLM } from './llm/provider.js';
 **Step 5: Build and run tests**
 
 ```bash
-cd /Users/Dave_Kerr/repos/github/gdog/corespec/packages/corespec && pnpm build && pnpm test
+cd $HOME/repos/github/gdog/corespec/packages/corespec && pnpm build && pnpm test
 ```
 
 Expected: all tests PASS (provider tests don't call real LLM).
@@ -679,7 +679,7 @@ describe('judgeFramework', () => {
 **Step 2: Run test to verify it fails**
 
 ```bash
-cd /Users/Dave_Kerr/repos/github/gdog/corespec/packages/corespec && pnpm build && pnpm test
+cd $HOME/repos/github/gdog/corespec/packages/corespec && pnpm build && pnpm test
 ```
 
 Expected: FAIL — `judgeFramework` not found.
@@ -748,7 +748,7 @@ export { judgeFramework } from './tools/judge-framework.js';
 **Step 5: Build and run tests**
 
 ```bash
-cd /Users/Dave_Kerr/repos/github/gdog/corespec/packages/corespec && pnpm build && pnpm test
+cd $HOME/repos/github/gdog/corespec/packages/corespec && pnpm build && pnpm test
 ```
 
 Expected: all tests PASS.
@@ -876,7 +876,7 @@ describe('judgeDiff', () => {
 **Step 2: Run test to verify it fails**
 
 ```bash
-cd /Users/Dave_Kerr/repos/github/gdog/corespec/packages/corespec && pnpm build && pnpm test
+cd $HOME/repos/github/gdog/corespec/packages/corespec && pnpm build && pnpm test
 ```
 
 Expected: FAIL — `judgeDiff` not found.
@@ -959,7 +959,7 @@ export { judgeDiff } from './tools/judge-diff.js';
 **Step 5: Build and run tests**
 
 ```bash
-cd /Users/Dave_Kerr/repos/github/gdog/corespec/packages/corespec && pnpm build && pnpm test
+cd $HOME/repos/github/gdog/corespec/packages/corespec && pnpm build && pnpm test
 ```
 
 Expected: all tests PASS.
@@ -1054,7 +1054,7 @@ describe('loadConfig', () => {
 **Step 2: Run test to verify it fails**
 
 ```bash
-cd /Users/Dave_Kerr/repos/github/gdog/corespec/packages/specguard && pnpm build && pnpm test
+cd $HOME/repos/github/gdog/corespec/packages/specguard && pnpm build && pnpm test
 ```
 
 Expected: FAIL.
@@ -1124,12 +1124,12 @@ Update `packages/specguard/package.json` — add to dependencies:
 "@getcorespec/corespec": "workspace:*"
 ```
 
-Run: `cd /Users/Dave_Kerr/repos/github/gdog/corespec && pnpm install`
+Run: `cd $HOME/repos/github/gdog/corespec && pnpm install`
 
 **Step 5: Build and run tests**
 
 ```bash
-cd /Users/Dave_Kerr/repos/github/gdog/corespec && pnpm -r build && cd packages/specguard && pnpm test
+cd $HOME/repos/github/gdog/corespec && pnpm -r build && cd packages/specguard && pnpm test
 ```
 
 Expected: all tests PASS.
@@ -1269,7 +1269,7 @@ describe('formatHuman', () => {
 **Step 3: Run tests to verify they fail**
 
 ```bash
-cd /Users/Dave_Kerr/repos/github/gdog/corespec/packages/specguard && pnpm build && pnpm test
+cd $HOME/repos/github/gdog/corespec/packages/specguard && pnpm build && pnpm test
 ```
 
 Expected: FAIL.
@@ -1385,7 +1385,7 @@ export function formatHuman(result: PipelineResult): string {
 **Step 6: Build and run tests**
 
 ```bash
-cd /Users/Dave_Kerr/repos/github/gdog/corespec && pnpm -r build && cd packages/specguard && pnpm test
+cd $HOME/repos/github/gdog/corespec && pnpm -r build && cd packages/specguard && pnpm test
 ```
 
 Expected: all tests PASS.
@@ -1456,7 +1456,7 @@ describe('specguard CLI', () => {
 **Step 2: Run test to verify it fails**
 
 ```bash
-cd /Users/Dave_Kerr/repos/github/gdog/corespec/packages/specguard && pnpm build && pnpm test
+cd $HOME/repos/github/gdog/corespec/packages/specguard && pnpm build && pnpm test
 ```
 
 Expected: FAIL — check command not registered.
@@ -1545,7 +1545,7 @@ program.parse();
 **Step 5: Build and run tests**
 
 ```bash
-cd /Users/Dave_Kerr/repos/github/gdog/corespec && pnpm -r build && cd packages/specguard && pnpm test
+cd $HOME/repos/github/gdog/corespec && pnpm -r build && cd packages/specguard && pnpm test
 ```
 
 Expected: all tests PASS.
@@ -1564,7 +1564,7 @@ git commit -m "feat(specguard): wire up check command with pipeline"
 **Step 1: Run full build and test from root**
 
 ```bash
-cd /Users/Dave_Kerr/repos/github/gdog/corespec && pnpm -r build && pnpm -r test
+cd $HOME/repos/github/gdog/corespec && pnpm -r build && pnpm -r test
 ```
 
 Expected: all packages build clean, all tests pass.


### PR DESCRIPTION
## Summary
- Add `.github/CODEOWNERS` with `@gaspodewonder` as owner
- Add Claude Code identity guard hook that blocks commits/pushes unless identity is `gaspodewonder`
- Hook also blocks `/Users/<username>/` paths from being written to files
- Redact all `/Users/Dave_Kerr/` paths in `docs/plans/` to `$HOME/`