### PR TITLE
fix: clean error messages, narrow output width, update docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,13 @@ install: # Build and install both CLIs globally.
 	npm install -g --force ./packages/specguard
 	npm install -g --force ./packages/respec
 
+.PHONY: install-dev
+install-dev: # Build and link both CLIs for local development.
+	pnpm install
+	pnpm -r build
+	npm link ./packages/specguard
+	npm link ./packages/respec
+
 .PHONY: build
 build: # Build all packages.
 	pnpm -r build

--- a/README.md
+++ b/README.md
@@ -22,6 +22,13 @@ PR gating for specs. Checks that code changes have an associated specification b
   <img src="./packages/specguard/docs/screenshots/failed-pr.png" width="420" alt="specguard gating a PR">
 </p>
 
+Specguard can:
+
+- [Be run from the CLI](./packages/specguard/README.md#quickstart)
+- [Be setup as a pre-commit hook](./packages/specguard/README.md#pre-commit-hook) or [Claude Code hook](./packages/specguard/README.md#claude-code-hook)
+- [Run as a GitHub Action](./packages/specguard/README.md#github-action)
+- Be configured as a bot
+
 ### [respec](./packages/respec/)
 
 Retroactive spec generation. Analyzes existing code and PRs to generate structured specifications. Built on corespec.

--- a/packages/specguard/README.md
+++ b/packages/specguard/README.md
@@ -66,6 +66,19 @@ specguard hook install
 
 This writes a `.git/hooks/pre-commit` script that runs `specguard check --staged` against your staged changes. If spec coverage is below the threshold, the commit is blocked.
 
+To install manually, create `.git/hooks/pre-commit`:
+
+```bash
+#!/bin/sh
+npx specguard check --staged
+```
+
+Then make it executable:
+
+```bash
+chmod +x .git/hooks/pre-commit
+```
+
 To overwrite an existing pre-commit hook:
 
 ```bash

--- a/packages/specguard/package.json
+++ b/packages/specguard/package.json
@@ -44,6 +44,7 @@
     "node": ">=20"
   },
   "dependencies": {
+    "@ai-sdk/provider": "^3.0.8",
     "@getcorespec/corespec": "workspace:*",
     "chalk": "^5.4.1",
     "commander": "^13.1.0",

--- a/packages/specguard/src/cli/commands/check.ts
+++ b/packages/specguard/src/cli/commands/check.ts
@@ -1,5 +1,6 @@
 import { Command } from 'commander';
 import { execSync } from 'child_process';
+import { APICallError } from '@ai-sdk/provider';
 import { loadConfig } from '../../core/config.js';
 import { runPipeline } from '../../core/pipeline.js';
 import { formatHuman, formatJson } from '../../core/formatter.js';
@@ -40,13 +41,23 @@ export const checkCommand = new Command('check')
 
     const repoRoot = execSync('git rev-parse --show-toplevel', { encoding: 'utf-8' }).trim();
 
-    const result = await runPipeline({
-      repoRoot,
-      diff,
-      model: config.model,
-      threshold: config.threshold,
-      baseURL: config.baseURL,
-    });
+    let result;
+    try {
+      result = await runPipeline({
+        repoRoot,
+        diff,
+        model: config.model,
+        threshold: config.threshold,
+        baseURL: config.baseURL,
+      });
+    } catch (err: unknown) {
+      if (APICallError.isInstance(err) && err.statusCode === 401) {
+        console.error('Error: invalid or missing API key. Set ANTHROPIC_API_KEY or OPENAI_API_KEY.');
+      } else {
+        console.error(`Error: LLM call failed — ${err instanceof Error ? err.message : String(err)}`);
+      }
+      process.exit(1);
+    }
 
     if (options.output === 'json') {
       console.log(formatJson(result));

--- a/packages/specguard/src/core/formatter.ts
+++ b/packages/specguard/src/core/formatter.ts
@@ -42,8 +42,11 @@ export function formatHuman(result: PipelineResult): string {
   for (const file of result.diff.files) {
     const score = file.score.toFixed(2);
     const icon = file.pass ? chalk.green('\u2713') : chalk.red('\u2717');
-    const gap = file.gap ? `  ${file.gap}` : '';
-    lines.push(`  ${file.file.padEnd(30)} ${score}  ${icon}${gap}`);
+    const name = file.file.length > 40 ? '\u2026' + file.file.slice(-39) : file.file;
+    lines.push(`  ${name.padEnd(41)} ${score}  ${icon}`);
+    if (file.gap) {
+      lines.push(chalk.dim(`    ${file.gap}`));
+    }
   }
 
   lines.push('');

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -106,6 +106,9 @@ importers:
 
   packages/specguard:
     dependencies:
+      '@ai-sdk/provider':
+        specifier: ^3.0.8
+        version: 3.0.8
       '@getcorespec/corespec':
         specifier: workspace:*
         version: link:../corespec


### PR DESCRIPTION
## Summary
- Catch LLM auth errors by `statusCode === 401` via `APICallError.isInstance` instead of raw stack trace
- Truncate long file paths to 40 chars in human output; move gap text to its own dim line
- Replace TODO in specguard README with manual hook install instructions
- Add anchor links to root README bullet list
- Add `@ai-sdk/provider` as direct dep of specguard