### PR TITLE
fix: remove @ai-sdk/provider direct dep from specguard

### DIFF
--- a/packages/specguard/package.json
+++ b/packages/specguard/package.json
@@ -44,7 +44,6 @@
     "node": ">=20"
   },
   "dependencies": {
-    "@ai-sdk/provider": "^3.0.8",
     "@getcorespec/corespec": "workspace:*",
     "chalk": "^5.4.1",
     "commander": "^13.1.0",

--- a/packages/specguard/src/cli/commands/check.ts
+++ b/packages/specguard/src/cli/commands/check.ts
@@ -1,6 +1,5 @@
 import { Command } from 'commander';
 import { execSync } from 'child_process';
-import { APICallError } from '@ai-sdk/provider';
 import { loadConfig } from '../../core/config.js';
 import { runPipeline } from '../../core/pipeline.js';
 import { formatHuman, formatJson } from '../../core/formatter.js';
@@ -51,7 +50,7 @@ export const checkCommand = new Command('check')
         baseURL: config.baseURL,
       });
     } catch (err: unknown) {
-      if (APICallError.isInstance(err) && err.statusCode === 401) {
+      if (err instanceof Error && 'statusCode' in err && (err as { statusCode: unknown }).statusCode === 401) {
         console.error('Error: invalid or missing API key. Set ANTHROPIC_API_KEY or OPENAI_API_KEY.');
       } else {
         console.error(`Error: LLM call failed — ${err instanceof Error ? err.message : String(err)}`);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -106,9 +106,6 @@ importers:
 
   packages/specguard:
     dependencies:
-      '@ai-sdk/provider':
-        specifier: ^3.0.8
-        version: 3.0.8
       '@getcorespec/corespec':
         specifier: workspace:*
         version: link:../corespec


### PR DESCRIPTION
## Summary

- Removes `@ai-sdk/provider` as a direct dependency from `packages/specguard/package.json` — it is already a transitive dep via `@getcorespec/corespec` — and having it pinned directly caused npm install failures for end users
- Replaces `APICallError.isInstance()` in `check.ts` with a duck-type check to eliminate the import

Fixes #17

Generated with [Claude Code](https://claude.ai/code)