### PR TITLE
feat: pre-push hook + specguard reporting improvements

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,6 +55,25 @@ This separation prevents CLI option explosion as model parameters grow.
 
 `specguard hook install` writes `.git/hooks/pre-commit` using `npx specguard check --staged`. The `hook` command uses commander's subcommand pattern: `hookCommand.addCommand(installHookCommand)`. Subsequent subcommands (e.g. `hook uninstall`) follow the same pattern.
 
+## Running CLIs during development
+
+Each CLI package (`specguard`, `respec`) has a `start` script that builds then runs:
+
+```bash
+cd packages/specguard
+pnpm start check main..HEAD       # one-shot build + run
+pnpm start check --staged
+pnpm start hook install
+```
+
+**pnpm quirk**: don't put `--` between `start` and the CLI args — pnpm passes `--` through as a literal token. `pnpm start check ...` works; `pnpm start -- check ...` does not.
+
+The script is split as `prestart: tsc` + `start: node ./bin/<name>.js` so args reach the binary cleanly.
+
+### Terminal title
+
+On TTY output, the CLI sets the terminal title to the invoked subcommand (e.g. `specguard check`) via the xterm escape sequence `\x1b]2;…\x07`. This makes terminal screenshots self-labelling. It's a no-op for non-TTY output (CI, pipes) so captured logs stay clean.
+
 ## Terminal screenshots
 
 For README screenshots using shellwright, use a minimal prompt (`$ `) with no path/git info:
@@ -63,6 +82,8 @@ For README screenshots using shellwright, use a minimal prompt (`$ `) with no pa
 # Start session with minimal prompt
 export PS1='$ '
 ```
+
+Run the CLI as `specguard check …` (global bin via `make install`) rather than `pnpm start …` so the title bar and prompt both read as the end-user flow.
 
 If the command needs to be faked (e.g. LLM calls unavailable), alias the command name:
 

--- a/openspec/specs/diff-filtering/spec.md
+++ b/openspec/specs/diff-filtering/spec.md
@@ -1,7 +1,8 @@
 # diff-filtering Specification
 
 ## Purpose
-TBD - created by archiving change specguard-ignore-list. Update Purpose after archive.
+Controls what specguard's judge-diff tool sends to the LLM and how the LLM returns its verdict. Covers (1) filtering files out of the diff via the `ignore` config, (2) loading existing spec documents from the repo so the LLM can cross-reference them, and (3) the per-file `reason` field describing why each file passed or failed.
+
 ## Requirements
 ### Requirement: Config supports ignore patterns
 The `.specguard.yml` config file SHALL support an `ignore` key containing a list of glob patterns. Each pattern matches file paths in the diff.
@@ -43,4 +44,45 @@ The judge-diff prompt SHALL instruct the LLM to score structural/wiring changes 
 #### Scenario: Re-export added to barrel file
 - **WHEN** a diff adds a re-export line to an index.ts barrel file
 - **THEN** the LLM is guided to score it as 1.0 (no spec needed)
+
+### Requirement: Prompt exempts test files from requiring separate specs
+The judge-diff prompt SHALL instruct the LLM to score test files (matching `*.test.*` or `*.spec.*` patterns) as passing with reason "test file, self-documenting", because test files document their own behavior.
+
+#### Scenario: Test file in diff
+- **WHEN** a diff modifies `src/foo.test.ts`
+- **THEN** the LLM SHALL score it 1.0 with a reason noting it is a test file
+
+### Requirement: Existing spec documents are supplied to the LLM as context
+When judging a diff, the pipeline SHALL load the framework's spec documents from disk and pass them to `judgeDiff` via the `specs` parameter. The `judgeDiff` function SHALL include these documents in the LLM prompt under an "Existing spec documents" section so the LLM can assess whether changed code is covered.
+
+#### Scenario: OpenSpec framework with spec files on disk
+- **WHEN** the detected framework is `openspec`
+- **AND** `openspec/specs/**/*.md` files exist in the repo
+- **THEN** the pipeline SHALL load each spec file's contents and path
+- **AND** pass them to `judgeDiff` as `SpecDocument[]`
+
+#### Scenario: Spec documents appear in the LLM prompt
+- **WHEN** `judgeDiff` is called with a non-empty `specs` array
+- **THEN** the built prompt SHALL contain each spec's path and full content
+- **AND** instruct the LLM to cross-reference the diff against those specs
+
+#### Scenario: Unknown framework
+- **WHEN** the detected framework is not a recognised one with a known spec directory
+- **THEN** `loadSpecs` SHALL return an empty array
+- **AND** the prompt SHALL omit the "Existing spec documents" section
+
+### Requirement: Per-file reason field explains both passes and fails
+Every `FileCoverage` entry returned by `judgeDiff` SHALL have a `reason` field containing a one-line explanation of the score. For passing files it describes the covering spec or exemption; for failing files it describes the gap.
+
+#### Scenario: Passing file with covering spec
+- **WHEN** the LLM scores `src/foo.ts` at 0.9 because it's covered by `openspec/specs/foo/spec.md`
+- **THEN** the returned `FileCoverage.reason` SHALL be a one-line explanation referencing the spec (e.g. "covered by foo spec")
+
+#### Scenario: Failing file
+- **WHEN** the LLM scores `src/bar.ts` at 0.3 with no matching spec
+- **THEN** the returned `FileCoverage.reason` SHALL describe what spec coverage is missing
+
+#### Scenario: Backward compatibility with legacy `gap` field
+- **WHEN** an older LLM response provides `gap` instead of `reason`
+- **THEN** `judgeDiff` SHALL populate `reason` from the `gap` value
 

--- a/openspec/specs/diff-filtering/spec.md
+++ b/openspec/specs/diff-filtering/spec.md
@@ -71,6 +71,19 @@ When judging a diff, the pipeline SHALL load the framework's spec documents from
 - **THEN** `loadSpecs` SHALL return an empty array
 - **AND** the prompt SHALL omit the "Existing spec documents" section
 
+### Requirement: Non-JSON LLM responses produce actionable error messages
+When the LLM returns a response that is not parseable JSON, `judgeDiff` SHALL throw `LlmJsonParseError` carrying the raw response, the model name, and the underlying parse error. The error message SHALL include (1) the model name, (2) a short preview of the raw response, and (3) remediation guidance (e.g. try a more capable model, reduce prompt size). Bare `JSON.parse` errors SHALL NOT surface to CLI users.
+
+#### Scenario: LLM returns markdown prose instead of JSON
+- **WHEN** the LLM responds with `# Analysis\n\nThe diff looks good`
+- **THEN** `judgeDiff` SHALL throw `LlmJsonParseError`
+- **AND** the error message SHALL include the model name, a preview of the response, and guidance to try a more capable model or reduce prompt size
+
+#### Scenario: CLI surfaces the error cleanly
+- **WHEN** `specguard check` catches an `LlmJsonParseError`
+- **THEN** the CLI SHALL print `Error: <message>` with the actionable context
+- **AND** SHALL NOT print the raw `SyntaxError: Unexpected token` stack
+
 ### Requirement: Per-file reason field explains both passes and fails
 Every `FileCoverage` entry returned by `judgeDiff` SHALL have a `reason` field containing a one-line explanation of the score. For passing files it describes the covering spec or exemption; for failing files it describes the gap.
 

--- a/openspec/specs/hook-install/spec.md
+++ b/openspec/specs/hook-install/spec.md
@@ -1,0 +1,66 @@
+# hook-install Specification
+
+## Purpose
+The `specguard hook install` command installs a git hook that runs specguard checks automatically. Pre-push is the default (batches checks per push, avoids penalising frequent committers). Pre-commit is opt-in for instant feedback.
+
+## Requirements
+
+### Requirement: Default installs a pre-push hook
+`specguard hook install` with no flags SHALL write a pre-push hook script to `.git/hooks/pre-push`.
+
+#### Scenario: Default install
+- **WHEN** `specguard hook install` is run in a git repository
+- **THEN** a file SHALL be created at `.git/hooks/pre-push` with mode 0755
+- **AND** the script SHALL invoke `npx specguard check` with a commit range
+
+### Requirement: Pre-push hook reads ref ranges from stdin
+The pre-push script SHALL parse git's stdin protocol (`local_ref local_sha remote_ref remote_sha`) to determine the commit range.
+
+#### Scenario: Existing remote branch
+- **WHEN** `remote_sha` is not the zero SHA
+- **THEN** the range SHALL be `remote_sha..local_sha`
+
+#### Scenario: New branch (no remote tracking)
+- **WHEN** `remote_sha` is the zero SHA (`0000000000000000000000000000000000000000`)
+- **THEN** the hook SHALL compute a base via `git merge-base HEAD origin/main`, falling back to `origin/master`, then to the initial commit
+- **AND** the range SHALL be `base..local_sha`
+
+#### Scenario: Deleted branch
+- **WHEN** `local_sha` is the zero SHA
+- **THEN** the hook SHALL skip that ref (no specguard check)
+
+### Requirement: --pre-commit installs a pre-commit hook
+`specguard hook install --pre-commit` SHALL write a pre-commit hook to `.git/hooks/pre-commit` that runs `npx specguard check --staged`.
+
+#### Scenario: Pre-commit install
+- **WHEN** `specguard hook install --pre-commit` is run
+- **THEN** a file SHALL be created at `.git/hooks/pre-commit`
+- **AND** the script SHALL invoke `npx specguard check --staged`
+
+### Requirement: Existing hook requires --force
+If the target hook file already exists, the command SHALL exit with an error unless `--force` is provided.
+
+#### Scenario: Hook already exists without --force
+- **WHEN** `.git/hooks/pre-push` already exists
+- **AND** `specguard hook install` is run without `--force`
+- **THEN** the command SHALL exit with code 1 and print an error
+
+#### Scenario: Hook already exists with --force
+- **WHEN** `.git/hooks/pre-push` already exists
+- **AND** `specguard hook install --force` is run
+- **THEN** the existing hook SHALL be overwritten
+
+### Requirement: Non-repo exits with error
+Running outside a git repository SHALL print an error and exit with code 1.
+
+#### Scenario: Not a git repo
+- **WHEN** `specguard hook install` is run outside a git repository
+- **THEN** the command SHALL exit with code 1
+- **AND** print "not inside a git repository"
+
+### Requirement: Hooks directory is created if missing
+If `.git/hooks` does not exist, the command SHALL create it before writing the hook.
+
+#### Scenario: Missing hooks directory
+- **WHEN** `.git/hooks` does not exist
+- **THEN** the command SHALL create the directory recursively before writing the hook file

--- a/openspec/specs/pr-comment/spec.md
+++ b/openspec/specs/pr-comment/spec.md
@@ -6,7 +6,7 @@ Defines how specguard presents coverage results in GitHub PR comments and check-
 ## Requirements
 
 ### Requirement: Framework name is rendered as a hyperlink when recognised
-When the detected framework has a known spec directory (e.g. `openspec` → `openspec/specs`), the PR comment and check-run output SHALL render the framework name as a markdown hyperlink pointing to that directory on the PR's head ref. This lets reviewers click through to the actual spec sources being evaluated against.
+When the detected framework has a verified spec directory convention (e.g. `openspec` → `openspec/specs`), the PR comment and check-run output SHALL render the framework name as a markdown hyperlink pointing to that directory on the PR's head ref. This lets reviewers click through to the actual spec sources being evaluated against. Only frameworks whose directory convention has been verified against their canonical project are recognised — the mapping SHALL NOT guess paths for unknown frameworks.
 
 #### Scenario: OpenSpec framework on a PR
 - **WHEN** the framework is `openspec`
@@ -14,12 +14,15 @@ When the detected framework has a known spec directory (e.g. `openspec` → `ope
 - **THEN** the comment SHALL contain `**Framework:** [openspec](https://github.com/getcorespec/corespec/tree/feature/x/openspec/specs)`
 
 #### Scenario: Unknown or no framework
-- **WHEN** the framework is `none` or lacks a known spec directory
+- **WHEN** the framework is `none` or not in the recognised mapping
 - **THEN** the framework SHALL appear as plain text, not a hyperlink
 
 #### Scenario: Framework directory mapping
-- **WHEN** the framework is one of: `openspec`, `kiro`, `superpowers`, `generic`
-- **THEN** the link SHALL target `openspec/specs`, `.kiro/specs`, `.claude/skills`, or `specs` respectively
+- **WHEN** the framework is one of the recognised set
+- **THEN** the link SHALL target:
+  - `openspec` → `openspec/specs` ([Fission-AI/OpenSpec](https://github.com/Fission-AI/OpenSpec))
+  - `kiro` → `.kiro/specs` ([kiro.dev](https://kiro.dev/docs/specs/))
+  - `superpowers` → `docs/superpowers/plans` ([obra/superpowers](https://github.com/obra/superpowers))
 
 ### Requirement: Coverage table includes a Reason column for every file
 The coverage table in PR comments and check-run outputs SHALL have columns `File`, `Score`, `Status`, `Reason`. Every row — passing or failing — SHALL display the per-file `reason` returned by `judgeDiff`.

--- a/openspec/specs/pr-comment/spec.md
+++ b/openspec/specs/pr-comment/spec.md
@@ -1,0 +1,37 @@
+# pr-comment Specification
+
+## Purpose
+Defines how specguard presents coverage results in GitHub PR comments and check-run outputs. Ensures reviewers can see which framework was detected (as a clickable link to the spec directory), the per-file scores, and a one-line reason explaining each score — including for items that pass.
+
+## Requirements
+
+### Requirement: Framework name is rendered as a hyperlink when recognised
+When the detected framework has a known spec directory (e.g. `openspec` → `openspec/specs`), the PR comment and check-run output SHALL render the framework name as a markdown hyperlink pointing to that directory on the PR's head ref. This lets reviewers click through to the actual spec sources being evaluated against.
+
+#### Scenario: OpenSpec framework on a PR
+- **WHEN** the framework is `openspec`
+- **AND** the PR head is `feature/x` on repo `getcorespec/corespec`
+- **THEN** the comment SHALL contain `**Framework:** [openspec](https://github.com/getcorespec/corespec/tree/feature/x/openspec/specs)`
+
+#### Scenario: Unknown or no framework
+- **WHEN** the framework is `none` or lacks a known spec directory
+- **THEN** the framework SHALL appear as plain text, not a hyperlink
+
+#### Scenario: Framework directory mapping
+- **WHEN** the framework is one of: `openspec`, `kiro`, `superpowers`, `generic`
+- **THEN** the link SHALL target `openspec/specs`, `.kiro/specs`, `.claude/skills`, or `specs` respectively
+
+### Requirement: Coverage table includes a Reason column for every file
+The coverage table in PR comments and check-run outputs SHALL have columns `File`, `Score`, `Status`, `Reason`. Every row — passing or failing — SHALL display the per-file `reason` returned by `judgeDiff`.
+
+#### Scenario: Passing file row
+- **WHEN** a file passes with reason "covered by hook-install spec"
+- **THEN** the row SHALL show `:white_check_mark:` status and the reason text
+
+#### Scenario: Failing file row
+- **WHEN** a file fails with reason "no spec covers auth middleware"
+- **THEN** the row SHALL show `:x:` status and the reason text
+
+#### Scenario: Legacy payload without reason
+- **WHEN** a payload item has `gap` but no `reason` (older specguard versions)
+- **THEN** the table SHALL fall back to the `gap` value for the Reason cell

--- a/packages/bot/src/handlers/specguard.test.ts
+++ b/packages/bot/src/handlers/specguard.test.ts
@@ -89,7 +89,7 @@ describe('createSpecguardHandler', () => {
       signals: { signals: [], candidates: [] },
       framework: { framework: 'openspec', confidence: 0.95, reasoning: '' },
       diff: {
-        files: [{ file: 'src/index.ts', score: 0.9, pass: true }],
+        files: [{ file: 'src/index.ts', score: 0.9, pass: true, reason: 'covered' }],
         result: 'pass',
         threshold: 0.7,
       },

--- a/packages/bot/src/handlers/specguard.ts
+++ b/packages/bot/src/handlers/specguard.ts
@@ -67,9 +67,10 @@ export function createSpecguardHandler(
       });
 
       const conclusion = result.diff.result === 'pass' ? 'success' : 'failure';
-      const output = formatCheckRunOutput(result);
+      const prCtx = { repoFullName: repo.full_name, headRef: pr.head.ref };
+      const output = formatCheckRunOutput(result, prCtx);
       await updateCheckRun(octokit, owner, repoName, checkRunId, conclusion, output);
-      await upsertComment(octokit, owner, repoName, pr.number, formatPrComment(result));
+      await upsertComment(octokit, owner, repoName, pr.number, formatPrComment(result, prCtx));
 
       console.log(`[specguard] PR #${pr.number}: ${conclusion}`);
     } catch (err) {

--- a/packages/bot/src/lib/format.test.ts
+++ b/packages/bot/src/lib/format.test.ts
@@ -15,7 +15,7 @@ function makeResult(overrides: { result?: 'pass' | 'fail'; files?: any[] } = {})
     },
     diff: {
       files: overrides.files ?? [
-        { file: 'src/index.ts', score: 0.9, pass: true },
+        { file: 'src/index.ts', score: 0.9, pass: true, reason: 'covered by index spec' },
       ],
       result: overrides.result ?? 'pass',
       threshold: 0.7,
@@ -35,11 +35,26 @@ describe('formatPrComment', () => {
   it('formats a failing result', () => {
     const md = formatPrComment(makeResult({
       result: 'fail',
-      files: [{ file: 'src/bad.ts', score: 0.3, pass: false, gap: 'Missing tests' }],
+      files: [{ file: 'src/bad.ts', score: 0.3, pass: false, reason: 'Missing tests' }],
     }));
     expect(md).toContain(':x: **specguard: FAIL**');
     expect(md).toContain('`src/bad.ts`');
     expect(md).toContain('Missing tests');
+  });
+
+  it('renders openspec framework as a hyperlink to the spec directory on the PR head', () => {
+    const md = formatPrComment(makeResult(), {
+      repoFullName: 'getcorespec/corespec',
+      headRef: 'feature/x',
+    });
+    expect(md).toContain(
+      '**Framework:** [openspec](https://github.com/getcorespec/corespec/tree/feature/x/openspec/specs)',
+    );
+  });
+
+  it('includes Reason header column', () => {
+    const md = formatPrComment(makeResult());
+    expect(md).toContain('| File | Score | Status | Reason |');
   });
 });
 
@@ -56,8 +71,8 @@ describe('formatCheckRunOutput', () => {
     const output = formatCheckRunOutput(makeResult({
       result: 'fail',
       files: [
-        { file: 'a.ts', score: 0.9, pass: true },
-        { file: 'b.ts', score: 0.3, pass: false, gap: 'No tests' },
+        { file: 'a.ts', score: 0.9, pass: true, reason: 'covered' },
+        { file: 'b.ts', score: 0.3, pass: false, reason: 'No tests' },
       ],
     }));
     expect(output.title).toBe('specguard: FAIL');

--- a/packages/bot/src/lib/format.ts
+++ b/packages/bot/src/lib/format.ts
@@ -1,29 +1,51 @@
 import type { PipelineResult } from '@getcorespec/specguard';
 
-export function formatPrComment(result: PipelineResult): string {
+// Maps a framework name to the repo directory holding its specs. Used to build
+// hyperlinks in the PR comment so reviewers can click through to the spec sources.
+const FRAMEWORK_SPEC_DIRS: Record<string, string> = {
+  openspec: 'openspec/specs',
+  kiro: '.kiro/specs',
+  superpowers: '.claude/skills',
+  generic: 'specs',
+};
+
+function renderFrameworkLink(framework: string, repoFullName?: string, headRef?: string): string {
+  const dir = FRAMEWORK_SPEC_DIRS[framework];
+  if (!dir || !repoFullName || !headRef || framework === 'none') return framework;
+  return `[${framework}](https://github.com/${repoFullName}/tree/${headRef}/${dir})`;
+}
+
+export interface PrContext {
+  repoFullName?: string;
+  headRef?: string;
+}
+
+export function formatPrComment(result: PipelineResult, ctx: PrContext = {}): string {
   const passed = result.diff.result === 'pass';
   const icon = passed ? ':white_check_mark:' : ':x:';
   const title = passed ? 'specguard: PASS' : 'specguard: FAIL';
 
   const rows = result.diff.files.map((f) => {
     const status = f.pass ? ':white_check_mark:' : ':x:';
-    const gap = f.gap ?? '-';
-    return `| \`${f.file}\` | ${f.score} | ${status} | ${gap} |`;
+    const reason = f.reason || '-';
+    return `| \`${f.file}\` | ${f.score} | ${status} | ${reason} |`;
   });
+
+  const frameworkLink = renderFrameworkLink(result.framework.framework, ctx.repoFullName, ctx.headRef);
 
   return [
     `${icon} **${title}**`,
     '',
-    `**Framework:** ${result.framework.framework} (confidence: ${result.framework.confidence})`,
+    `**Framework:** ${frameworkLink} (confidence: ${result.framework.confidence})`,
     `**Threshold:** ${result.diff.threshold}`,
     '',
-    '| File | Score | Status | Gap |',
-    '|------|-------|--------|-----|',
+    '| File | Score | Status | Reason |',
+    '|------|-------|--------|--------|',
     ...rows,
   ].join('\n');
 }
 
-export function formatCheckRunOutput(result: PipelineResult): {
+export function formatCheckRunOutput(result: PipelineResult, ctx: PrContext = {}): {
   title: string;
   summary: string;
   text: string;
@@ -34,16 +56,18 @@ export function formatCheckRunOutput(result: PipelineResult): {
 
   const rows = result.diff.files.map((f) => {
     const status = f.pass ? '\u2705' : '\u274c';
-    const gap = f.gap ?? '-';
-    return `| \`${f.file}\` | ${f.score} | ${status} | ${gap} |`;
+    const reason = f.reason || '-';
+    return `| \`${f.file}\` | ${f.score} | ${status} | ${reason} |`;
   });
 
+  const frameworkLink = renderFrameworkLink(result.framework.framework, ctx.repoFullName, ctx.headRef);
+
   const text = [
-    `**Framework:** ${result.framework.framework} (confidence: ${result.framework.confidence})`,
+    `**Framework:** ${frameworkLink} (confidence: ${result.framework.confidence})`,
     `**Threshold:** ${result.diff.threshold}`,
     '',
-    '| File | Score | Status | Gap |',
-    '|------|-------|--------|-----|',
+    '| File | Score | Status | Reason |',
+    '|------|-------|--------|--------|',
     ...rows,
   ].join('\n');
 

--- a/packages/bot/src/lib/format.ts
+++ b/packages/bot/src/lib/format.ts
@@ -1,12 +1,17 @@
 import type { PipelineResult } from '@getcorespec/specguard';
 
-// Maps a framework name to the repo directory holding its specs. Used to build
-// hyperlinks in the PR comment so reviewers can click through to the spec sources.
+// Maps a recognised spec framework to the repo directory holding its spec/plan
+// documents. Used to build hyperlinks in the PR comment so reviewers can click
+// through to the spec sources. Only frameworks with a known, verified convention
+// are listed here — unrecognised frameworks render as plain text.
+//
+// - OpenSpec:    https://github.com/Fission-AI/OpenSpec
+// - Kiro:        https://kiro.dev/docs/specs/
+// - Superpowers: https://github.com/obra/superpowers
 const FRAMEWORK_SPEC_DIRS: Record<string, string> = {
   openspec: 'openspec/specs',
   kiro: '.kiro/specs',
-  superpowers: '.claude/skills',
-  generic: 'specs',
+  superpowers: 'docs/superpowers/plans',
 };
 
 function renderFrameworkLink(framework: string, repoFullName?: string, headRef?: string): string {

--- a/packages/corespec/src/index.ts
+++ b/packages/corespec/src/index.ts
@@ -10,7 +10,7 @@ export type {
 
 export { checkFramework } from './tools/check-framework.js';
 export { judgeFramework } from './tools/judge-framework.js';
-export { judgeDiff } from './tools/judge-diff.js';
+export { judgeDiff, LlmJsonParseError } from './tools/judge-diff.js';
 export { loadSpecs } from './tools/load-specs.js';
 
 export { parseModelId, callLLM } from './llm/provider.js';

--- a/packages/corespec/src/index.ts
+++ b/packages/corespec/src/index.ts
@@ -10,8 +10,9 @@ export type {
 
 export { checkFramework } from './tools/check-framework.js';
 export { judgeFramework } from './tools/judge-framework.js';
-export { judgeDiff, LlmJsonParseError } from './tools/judge-diff.js';
+export { judgeDiff } from './tools/judge-diff.js';
 export { loadSpecs } from './tools/load-specs.js';
+export { extractJsonObject, parseLlmJson, LlmJsonParseError } from './llm/json-response.js';
 
 export { parseModelId, callLLM } from './llm/provider.js';
 

--- a/packages/corespec/src/index.ts
+++ b/packages/corespec/src/index.ts
@@ -5,11 +5,13 @@ export type {
   FileCoverage,
   DiffJudgment,
   ModelConfig,
+  SpecDocument,
 } from './types.js';
 
 export { checkFramework } from './tools/check-framework.js';
 export { judgeFramework } from './tools/judge-framework.js';
 export { judgeDiff } from './tools/judge-diff.js';
+export { loadSpecs } from './tools/load-specs.js';
 
 export { parseModelId, callLLM } from './llm/provider.js';
 

--- a/packages/corespec/src/llm/json-response.test.ts
+++ b/packages/corespec/src/llm/json-response.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+import { extractJsonObject, parseLlmJson, LlmJsonParseError } from './json-response.js';
+
+describe('extractJsonObject', () => {
+  it('extracts a plain JSON object', () => {
+    expect(extractJsonObject('{"a":1}')).toBe('{"a":1}');
+  });
+
+  it('strips markdown code fences', () => {
+    expect(extractJsonObject('```json\n{"a":1}\n```')).toBe('{"a":1}');
+  });
+
+  it('ignores leading prose', () => {
+    expect(extractJsonObject('Here is my answer:\n{"a":1}')).toBe('{"a":1}');
+  });
+
+  it('ignores trailing prose after the JSON object', () => {
+    expect(extractJsonObject('{"a":1}\n\nLet me know if you need more.')).toBe('{"a":1}');
+  });
+
+  it('handles nested objects', () => {
+    expect(extractJsonObject('junk { "a": { "b": 1 } } trailing')).toBe('{ "a": { "b": 1 } }');
+  });
+
+  it('ignores braces inside strings', () => {
+    expect(extractJsonObject('{"a":"has { brace"}')).toBe('{"a":"has { brace"}');
+  });
+});
+
+describe('parseLlmJson', () => {
+  it('parses a valid JSON response', () => {
+    const result = parseLlmJson<{ a: number }>('{"a":1}', 'test-model');
+    expect(result).toEqual({ a: 1 });
+  });
+
+  it('parses through markdown fences and prose', () => {
+    const raw = 'Sure, here you go:\n```json\n{"a":1}\n```\nHope that helps!';
+    expect(parseLlmJson(raw, 'test-model')).toEqual({ a: 1 });
+  });
+
+  it('throws LlmJsonParseError with actionable context on unparseable response', () => {
+    const bogus = '# Coverage Analysis\n\nI reviewed the diff and here are my findings.';
+    try {
+      parseLlmJson(bogus, 'anthropic/claude-haiku-4-5');
+      expect.fail('expected parseLlmJson to throw');
+    } catch (err) {
+      expect(err).toBeInstanceOf(LlmJsonParseError);
+      const typed = err as LlmJsonParseError;
+      expect(typed.model).toBe('anthropic/claude-haiku-4-5');
+      expect(typed.rawResponse).toBe(bogus);
+      expect(typed.message).toContain('claude-haiku-4-5');
+      expect(typed.message).toContain('Coverage Analysis');
+      expect(typed.message).toContain('Try a more capable model');
+    }
+  });
+});

--- a/packages/corespec/src/llm/json-response.ts
+++ b/packages/corespec/src/llm/json-response.ts
@@ -1,0 +1,90 @@
+/**
+ * Utilities for parsing JSON responses from LLM calls.
+ *
+ * LLMs frequently wrap JSON in markdown code fences or add conversational
+ * prose before/after the object, even when explicitly told not to. These
+ * helpers extract the first balanced JSON object from such responses and
+ * wrap parse failures in an actionable error.
+ */
+
+/**
+ * Extracts the first balanced JSON object from an LLM response string,
+ * tolerating leading/trailing prose, markdown code fences, or commentary.
+ *
+ * Returns the trimmed original string if no `{` is found, so the caller's
+ * `JSON.parse` produces a meaningful error location.
+ */
+export function extractJsonObject(raw: string): string {
+  const stripped = raw.replace(/```(?:json)?\s*/g, '').replace(/\s*```/g, '');
+  const start = stripped.indexOf('{');
+  if (start === -1) return stripped.trim();
+
+  let depth = 0;
+  let inString = false;
+  let escape = false;
+  for (let i = start; i < stripped.length; i++) {
+    const ch = stripped[i];
+    if (inString) {
+      if (escape) {
+        escape = false;
+      } else if (ch === '\\') {
+        escape = true;
+      } else if (ch === '"') {
+        inString = false;
+      }
+      continue;
+    }
+    if (ch === '"') {
+      inString = true;
+    } else if (ch === '{') {
+      depth++;
+    } else if (ch === '}') {
+      depth--;
+      if (depth === 0) {
+        return stripped.slice(start, i + 1);
+      }
+    }
+  }
+  return stripped.slice(start).trim();
+}
+
+/**
+ * Thrown when an LLM returns a response that cannot be parsed as JSON.
+ * Carries the raw response, model name, and underlying parse error so
+ * callers can surface actionable messages instead of bare `SyntaxError`s.
+ */
+export class LlmJsonParseError extends Error {
+  public readonly rawResponse: string;
+  public readonly model: string;
+  public readonly parseError: string;
+
+  constructor(parseError: string, rawResponse: string, model: string) {
+    const preview = rawResponse.trim().slice(0, 200).replace(/\s+/g, ' ');
+    const suffix = rawResponse.length > 200 ? '…' : '';
+    super(
+      `LLM returned a non-JSON response (model: ${model}). ` +
+        `JSON parse error: ${parseError}. ` +
+        `Response preview: "${preview}${suffix}". ` +
+        `The model likely ignored the JSON-only instruction. Try a more capable model ` +
+        `(e.g. claude-sonnet-4) or reduce the prompt size by tightening the ignore list in .specguard.yml.`,
+    );
+    this.name = 'LlmJsonParseError';
+    this.rawResponse = rawResponse;
+    this.model = model;
+    this.parseError = parseError;
+  }
+}
+
+/**
+ * Extracts and parses a JSON object from an LLM response, wrapping any
+ * parse failure in {@link LlmJsonParseError} with full context.
+ */
+export function parseLlmJson<T = unknown>(raw: string, model: string): T {
+  const extracted = extractJsonObject(raw);
+  try {
+    return JSON.parse(extracted) as T;
+  } catch (err) {
+    const parseMessage = err instanceof Error ? err.message : String(err);
+    throw new LlmJsonParseError(parseMessage, raw, model);
+  }
+}

--- a/packages/corespec/src/tools/check-framework.test.ts
+++ b/packages/corespec/src/tools/check-framework.test.ts
@@ -31,9 +31,9 @@ describe('checkFramework', () => {
     expect(result.signals.some(s => s.framework === 'openspec')).toBe(true);
   });
 
-  it('detects superpowers skills directory', () => {
-    mkdirSync(join(tempDir, '.claude', 'skills'), { recursive: true });
-    writeFileSync(join(tempDir, '.claude', 'skills', 'test.md'), '# Skill');
+  it('detects superpowers via docs/superpowers/plans directory', () => {
+    mkdirSync(join(tempDir, 'docs', 'superpowers', 'plans'), { recursive: true });
+    writeFileSync(join(tempDir, 'docs', 'superpowers', 'plans', '2026-04-15-foo.md'), '# Plan');
 
     const result = checkFramework(tempDir);
 
@@ -41,14 +41,13 @@ describe('checkFramework', () => {
     expect(result.signals.some(s => s.framework === 'superpowers')).toBe(true);
   });
 
-  it('detects generic specs directory', () => {
-    mkdirSync(join(tempDir, 'specs'), { recursive: true });
-    writeFileSync(join(tempDir, 'specs', 'auth.spec.md'), '# Auth Spec');
+  it('does not report superpowers from a bare .claude/skills directory (any plugin)', () => {
+    mkdirSync(join(tempDir, '.claude', 'skills'), { recursive: true });
+    writeFileSync(join(tempDir, '.claude', 'skills', 'test.md'), '# Skill');
 
     const result = checkFramework(tempDir);
 
-    expect(result.candidates).toContain('generic');
-    expect(result.signals.some(s => s.signal.includes('specs/'))).toBe(true);
+    expect(result.candidates).not.toContain('superpowers');
   });
 
   it('detects kiro config', () => {
@@ -72,8 +71,8 @@ describe('checkFramework', () => {
   it('detects multiple frameworks', () => {
     mkdirSync(join(tempDir, 'openspec'), { recursive: true });
     writeFileSync(join(tempDir, 'openspec', 'spec.md'), '# Spec');
-    mkdirSync(join(tempDir, '.claude', 'skills'), { recursive: true });
-    writeFileSync(join(tempDir, '.claude', 'skills', 'test.md'), '# Skill');
+    mkdirSync(join(tempDir, 'docs', 'superpowers', 'plans'), { recursive: true });
+    writeFileSync(join(tempDir, 'docs', 'superpowers', 'plans', 'p.md'), '# Plan');
 
     const result = checkFramework(tempDir);
 

--- a/packages/corespec/src/tools/check-framework.ts
+++ b/packages/corespec/src/tools/check-framework.ts
@@ -25,12 +25,19 @@ const patterns: FrameworkPattern[] = [
     },
   },
   {
+    // Superpowers plans/specs live under docs/superpowers/ per obra/superpowers
+    // convention. Avoid matching on .claude/skills/ — that directory is present
+    // for any Claude Code plugin, not just superpowers.
     framework: 'superpowers',
     check: (root) => {
       const signals: FrameworkSignal[] = [];
-      const skillsDir = join(root, '.claude', 'skills');
-      if (existsSync(skillsDir) && statSync(skillsDir).isDirectory()) {
-        signals.push({ signal: '.claude/skills/ directory', framework: 'superpowers', path: '.claude/skills/' });
+      const plansDir = join(root, 'docs', 'superpowers', 'plans');
+      if (existsSync(plansDir) && statSync(plansDir).isDirectory()) {
+        signals.push({ signal: 'docs/superpowers/plans/ directory', framework: 'superpowers', path: 'docs/superpowers/plans/' });
+      }
+      const specsDir = join(root, 'docs', 'superpowers', 'specs');
+      if (existsSync(specsDir) && statSync(specsDir).isDirectory()) {
+        signals.push({ signal: 'docs/superpowers/specs/ directory', framework: 'superpowers', path: 'docs/superpowers/specs/' });
       }
       return signals;
     },
@@ -47,32 +54,6 @@ const patterns: FrameworkPattern[] = [
       const specsDir = join(root, '.kiro', 'specs');
       if (existsSync(specsDir) && statSync(specsDir).isDirectory()) {
         signals.push({ signal: '.kiro/specs/ directory', framework: 'kiro', path: '.kiro/specs/' });
-      }
-      return signals;
-    },
-  },
-  {
-    framework: 'generic',
-    check: (root) => {
-      const signals: FrameworkSignal[] = [];
-      const specsDir = join(root, 'specs');
-      if (existsSync(specsDir) && statSync(specsDir).isDirectory()) {
-        signals.push({ signal: 'specs/ directory', framework: 'generic', path: 'specs/' });
-      }
-      const docsSpecsDir = join(root, 'docs', 'specs');
-      if (existsSync(docsSpecsDir) && statSync(docsSpecsDir).isDirectory()) {
-        signals.push({ signal: 'docs/specs/ directory', framework: 'generic', path: 'docs/specs/' });
-      }
-      for (const name of safeReaddir(root)) {
-        const fullPath = join(root, name);
-        if (statSync(fullPath).isDirectory()) {
-          for (const file of safeReaddir(fullPath)) {
-            if (file.match(/\.spec\.md$/) || file.match(/\.requirements\.md$/)) {
-              const relPath = join(name, file);
-              signals.push({ signal: `${relPath} spec file`, framework: 'generic', path: relPath });
-            }
-          }
-        }
       }
       return signals;
     },

--- a/packages/corespec/src/tools/judge-diff.test.ts
+++ b/packages/corespec/src/tools/judge-diff.test.ts
@@ -66,8 +66,8 @@ describe('judgeDiff', () => {
 
     mockCallLLM.mockResolvedValueOnce(JSON.stringify({
       files: [
-        { file: 'src/auth/login.ts', score: 0.85, pass: true },
-        { file: 'src/auth/middleware.ts', score: 0.2, pass: false, gap: 'no spec covers auth middleware' },
+        { file: 'src/auth/login.ts', score: 0.85, pass: true, reason: 'covered by auth spec' },
+        { file: 'src/auth/middleware.ts', score: 0.2, pass: false, reason: 'no spec covers auth middleware' },
       ],
       result: 'fail',
       threshold: 0.7,
@@ -78,9 +78,58 @@ describe('judgeDiff', () => {
     expect(result.files).toHaveLength(2);
     expect(result.files[0].file).toBe('src/auth/login.ts');
     expect(result.files[0].pass).toBe(true);
+    expect(result.files[0].reason).toBe('covered by auth spec');
     expect(result.files[1].pass).toBe(false);
-    expect(result.files[1].gap).toBeTruthy();
+    expect(result.files[1].reason).toBe('no spec covers auth middleware');
     expect(result.result).toBe('fail');
+  });
+
+  it('includes existing spec documents in the LLM prompt', async () => {
+    const framework: FrameworkJudgment = {
+      framework: 'openspec',
+      confidence: 0.95,
+      reasoning: 'OpenSpec detected',
+    };
+
+    mockCallLLM.mockResolvedValueOnce(JSON.stringify({
+      files: [],
+      result: 'pass',
+      threshold: 0.7,
+    }));
+
+    await judgeDiff(
+      framework,
+      sampleDiff,
+      { model: 'anthropic/claude-sonnet-4-20250514' },
+      0.7,
+      [],
+      [
+        { path: 'openspec/specs/auth/spec.md', content: '# Auth Specification\nRequirement: users can log in' },
+      ],
+    );
+
+    const promptArg = mockCallLLM.mock.calls[0][1];
+    expect(promptArg).toContain('openspec/specs/auth/spec.md');
+    expect(promptArg).toContain('Auth Specification');
+  });
+
+  it('falls back to gap field when reason is not provided (backward compat)', async () => {
+    const framework: FrameworkJudgment = {
+      framework: 'none',
+      confidence: 0.1,
+      reasoning: 'No framework',
+    };
+
+    mockCallLLM.mockResolvedValueOnce(JSON.stringify({
+      files: [
+        { file: 'a.ts', score: 0.3, pass: false, gap: 'missing spec' },
+      ],
+      result: 'fail',
+      threshold: 0.7,
+    }));
+
+    const result = await judgeDiff(framework, sampleDiff, { model: 'anthropic/claude-sonnet-4-20250514' }, 0.7);
+    expect(result.files[0].reason).toBe('missing spec');
   });
 
   it('passes when all files meet threshold', async () => {
@@ -92,7 +141,7 @@ describe('judgeDiff', () => {
 
     mockCallLLM.mockResolvedValueOnce(JSON.stringify({
       files: [
-        { file: 'src/utils.ts', score: 0.9, pass: true },
+        { file: 'src/utils.ts', score: 0.9, pass: true, reason: 'utility, no spec needed' },
       ],
       result: 'pass',
       threshold: 0.7,

--- a/packages/corespec/src/tools/judge-diff.test.ts
+++ b/packages/corespec/src/tools/judge-diff.test.ts
@@ -5,7 +5,7 @@ vi.mock('../llm/provider.js', () => ({
   callLLM: vi.fn(),
 }));
 
-import { judgeDiff, filterDiff, extractJsonObject } from './judge-diff.js';
+import { judgeDiff, filterDiff, extractJsonObject, LlmJsonParseError } from './judge-diff.js';
 import { callLLM } from '../llm/provider.js';
 
 const mockCallLLM = vi.mocked(callLLM);
@@ -137,6 +137,32 @@ describe('judgeDiff', () => {
     const promptArg = mockCallLLM.mock.calls[0][1];
     expect(promptArg).toContain('openspec/specs/auth/spec.md');
     expect(promptArg).toContain('Auth Specification');
+  });
+
+  it('throws LlmJsonParseError with actionable context when LLM returns non-JSON', async () => {
+    const framework: FrameworkJudgment = {
+      framework: 'openspec',
+      confidence: 0.95,
+      reasoning: 'OpenSpec detected',
+    };
+
+    const bogusResponse = '# Spec Coverage Analysis\n\nI reviewed the diff and here are my findings:\n- Foo looks good';
+    mockCallLLM.mockResolvedValue(bogusResponse);
+
+    try {
+      await judgeDiff(framework, sampleDiff, { model: 'anthropic/claude-haiku-4-5' }, 0.7);
+      expect.fail('expected judgeDiff to throw');
+    } catch (err) {
+      expect(err).toBeInstanceOf(LlmJsonParseError);
+      const typed = err as LlmJsonParseError;
+      expect(typed.model).toBe('anthropic/claude-haiku-4-5');
+      expect(typed.rawResponse).toBe(bogusResponse);
+      // Surfaces the model, a response preview, and remediation advice so users
+      // don't just see a raw JSON.parse stack trace.
+      expect(typed.message).toContain('claude-haiku-4-5');
+      expect(typed.message).toContain('Spec Coverage Analysis');
+      expect(typed.message).toContain('Try a more capable model');
+    }
   });
 
   it('falls back to gap field when reason is not provided (backward compat)', async () => {

--- a/packages/corespec/src/tools/judge-diff.test.ts
+++ b/packages/corespec/src/tools/judge-diff.test.ts
@@ -5,7 +5,8 @@ vi.mock('../llm/provider.js', () => ({
   callLLM: vi.fn(),
 }));
 
-import { judgeDiff, filterDiff, extractJsonObject, LlmJsonParseError } from './judge-diff.js';
+import { judgeDiff, filterDiff } from './judge-diff.js';
+import { LlmJsonParseError } from '../llm/json-response.js';
 import { callLLM } from '../llm/provider.js';
 
 const mockCallLLM = vi.mocked(callLLM);
@@ -49,32 +50,6 @@ describe('filterDiff', () => {
   it('returns original diff when ignore list is empty', () => {
     const result = filterDiff(sampleDiff, []);
     expect(result).toBe(sampleDiff);
-  });
-});
-
-describe('extractJsonObject', () => {
-  it('extracts a plain JSON object', () => {
-    expect(extractJsonObject('{"a":1}')).toBe('{"a":1}');
-  });
-
-  it('strips markdown code fences', () => {
-    expect(extractJsonObject('```json\n{"a":1}\n```')).toBe('{"a":1}');
-  });
-
-  it('ignores leading prose', () => {
-    expect(extractJsonObject('Here is my answer:\n{"a":1}')).toBe('{"a":1}');
-  });
-
-  it('ignores trailing prose after the JSON object', () => {
-    expect(extractJsonObject('{"a":1}\n\nLet me know if you need more.')).toBe('{"a":1}');
-  });
-
-  it('handles nested objects', () => {
-    expect(extractJsonObject('junk { "a": { "b": 1 } } trailing')).toBe('{ "a": { "b": 1 } }');
-  });
-
-  it('ignores braces inside strings', () => {
-    expect(extractJsonObject('{"a":"has { brace"}')).toBe('{"a":"has { brace"}');
   });
 });
 

--- a/packages/corespec/src/tools/judge-diff.test.ts
+++ b/packages/corespec/src/tools/judge-diff.test.ts
@@ -5,7 +5,7 @@ vi.mock('../llm/provider.js', () => ({
   callLLM: vi.fn(),
 }));
 
-import { judgeDiff, filterDiff } from './judge-diff.js';
+import { judgeDiff, filterDiff, extractJsonObject } from './judge-diff.js';
 import { callLLM } from '../llm/provider.js';
 
 const mockCallLLM = vi.mocked(callLLM);
@@ -49,6 +49,32 @@ describe('filterDiff', () => {
   it('returns original diff when ignore list is empty', () => {
     const result = filterDiff(sampleDiff, []);
     expect(result).toBe(sampleDiff);
+  });
+});
+
+describe('extractJsonObject', () => {
+  it('extracts a plain JSON object', () => {
+    expect(extractJsonObject('{"a":1}')).toBe('{"a":1}');
+  });
+
+  it('strips markdown code fences', () => {
+    expect(extractJsonObject('```json\n{"a":1}\n```')).toBe('{"a":1}');
+  });
+
+  it('ignores leading prose', () => {
+    expect(extractJsonObject('Here is my answer:\n{"a":1}')).toBe('{"a":1}');
+  });
+
+  it('ignores trailing prose after the JSON object', () => {
+    expect(extractJsonObject('{"a":1}\n\nLet me know if you need more.')).toBe('{"a":1}');
+  });
+
+  it('handles nested objects', () => {
+    expect(extractJsonObject('junk { "a": { "b": 1 } } trailing')).toBe('{ "a": { "b": 1 } }');
+  });
+
+  it('ignores braces inside strings', () => {
+    expect(extractJsonObject('{"a":"has { brace"}')).toBe('{"a":"has { brace"}');
   });
 });
 

--- a/packages/corespec/src/tools/judge-diff.ts
+++ b/packages/corespec/src/tools/judge-diff.ts
@@ -1,4 +1,4 @@
-import type { FrameworkJudgment, DiffJudgment, ModelConfig } from '../types.js';
+import type { FrameworkJudgment, DiffJudgment, ModelConfig, SpecDocument } from '../types.js';
 import { callLLM } from '../llm/provider.js';
 import picomatch from 'picomatch';
 
@@ -33,27 +33,38 @@ export function filterDiff(diff: string, ignore: string[]): string {
   return hunks.join('\n');
 }
 
-function buildPrompt(framework: FrameworkJudgment, diff: string, threshold: number): string {
+function buildPrompt(
+  framework: FrameworkJudgment,
+  diff: string,
+  threshold: number,
+  specs: SpecDocument[],
+): string {
   const frameworkContext = framework.framework !== 'none'
     ? `The repository uses the "${framework.framework}" spec framework (confidence: ${framework.confidence}). ${framework.reasoning}`
     : 'No specific spec framework was detected in this repository.';
+
+  const specsSection = specs.length > 0
+    ? `\nExisting spec documents in the repository:\n${specs.map(s => `--- ${s.path} ---\n${s.content}`).join('\n\n')}\n`
+    : '';
 
   return `You are a spec coverage analysis tool. Given a git diff and information about the repository's spec framework, evaluate whether each changed file has adequate specification coverage.
 
 Framework context:
 ${frameworkContext}
-
+${specsSection}
 Pass/fail threshold: ${threshold} (files scoring below this fail)
 
 Git diff:
 ${diff}
 
 For each changed file in the diff, evaluate:
-1. Does this file have an associated spec that covers its behavior?
+1. Does this file have an associated spec that covers its behavior? Check the existing spec documents above — a file is covered if a spec describes its behavior, even if the spec lives elsewhere in the tree.
 2. How confident are you that the spec coverage is adequate? (0.0 = no coverage, 1.0 = fully specified)
-3. If coverage is inadequate, briefly explain what's missing.
+3. Provide a one-line reason explaining the score — for passing files, name the covering spec or explain why no spec is needed (e.g. "covered by hook-install spec", "test file, self-documenting", "structural change, no behavior"). For failing files, describe the gap.
 
 Structural or wiring changes that don't alter behavior — such as re-exports in barrel/index files, import path changes, or dependency version bumps — do not require spec coverage. Score these 1.0.
+
+Test files (e.g. *.test.ts, *.spec.ts) are self-documenting and do not require separate specs. Score these 1.0 with reason "test file, self-documenting".
 
 Respond with ONLY a JSON object (no markdown, no code fences):
 {
@@ -62,7 +73,7 @@ Respond with ONLY a JSON object (no markdown, no code fences):
       "file": "<file path>",
       "score": <0.0 to 1.0>,
       "pass": <true if score >= threshold>,
-      "gap": "<explanation of missing coverage, omit if passing>"
+      "reason": "<one-line explanation of the score>"
     }
   ],
   "result": "<'pass' if all files pass, 'fail' if any file fails>",
@@ -76,6 +87,7 @@ export async function judgeDiff(
   config: ModelConfig,
   threshold: number,
   ignore: string[] = [],
+  specs: SpecDocument[] = [],
 ): Promise<DiffJudgment> {
   const filteredDiff = filterDiff(diff, ignore);
 
@@ -83,17 +95,17 @@ export async function judgeDiff(
     return { files: [], result: 'pass', threshold };
   }
 
-  const prompt = buildPrompt(framework, filteredDiff, threshold);
+  const prompt = buildPrompt(framework, filteredDiff, threshold, specs);
   const raw = await callLLM(config, prompt);
   const response = raw.replace(/^```(?:json)?\s*\n?/gm, '').replace(/\n?```\s*$/gm, '').trim();
 
-  const parsed = JSON.parse(response) as DiffJudgment;
+  const parsed = JSON.parse(response) as { files?: Array<{ file: string; score?: number; reason?: string; gap?: string }>; threshold?: number };
 
   const files = (parsed.files ?? []).map(f => ({
     file: f.file,
     score: Math.max(0, Math.min(1, f.score ?? 0)),
     pass: (f.score ?? 0) >= threshold,
-    ...(f.gap ? { gap: f.gap } : {}),
+    reason: f.reason ?? f.gap ?? '',
   }));
 
   const result = files.every(f => f.pass) ? 'pass' as const : 'fail' as const;

--- a/packages/corespec/src/tools/judge-diff.ts
+++ b/packages/corespec/src/tools/judge-diff.ts
@@ -1,71 +1,7 @@
 import type { FrameworkJudgment, DiffJudgment, ModelConfig, SpecDocument } from '../types.js';
 import { callLLM } from '../llm/provider.js';
+import { parseLlmJson } from '../llm/json-response.js';
 import picomatch from 'picomatch';
-
-/**
- * Thrown when the LLM returns a response that is not parseable JSON.
- * Carries the raw response and model name so callers can surface actionable
- * error messages instead of bare JSON.parse output.
- */
-export class LlmJsonParseError extends Error {
-  public readonly rawResponse: string;
-  public readonly model: string;
-  public readonly parseError: string;
-
-  constructor(parseError: string, rawResponse: string, model: string) {
-    const preview = rawResponse.trim().slice(0, 200).replace(/\s+/g, ' ');
-    const suffix = rawResponse.length > 200 ? '…' : '';
-    super(
-      `LLM returned a non-JSON response (model: ${model}). ` +
-        `JSON parse error: ${parseError}. ` +
-        `Response preview: "${preview}${suffix}". ` +
-        `The model likely ignored the JSON-only instruction. Try a more capable model ` +
-        `(e.g. claude-sonnet-4) or reduce the prompt size by tightening the ignore list in .specguard.yml.`,
-    );
-    this.name = 'LlmJsonParseError';
-    this.rawResponse = rawResponse;
-    this.model = model;
-    this.parseError = parseError;
-  }
-}
-
-/**
- * Extracts the first balanced JSON object from an LLM response, tolerating
- * leading/trailing prose, markdown code fences, or commentary.
- */
-export function extractJsonObject(raw: string): string {
-  const stripped = raw.replace(/```(?:json)?\s*/g, '').replace(/\s*```/g, '');
-  const start = stripped.indexOf('{');
-  if (start === -1) return stripped.trim();
-
-  let depth = 0;
-  let inString = false;
-  let escape = false;
-  for (let i = start; i < stripped.length; i++) {
-    const ch = stripped[i];
-    if (inString) {
-      if (escape) {
-        escape = false;
-      } else if (ch === '\\') {
-        escape = true;
-      } else if (ch === '"') {
-        inString = false;
-      }
-      continue;
-    }
-    if (ch === '"') {
-      inString = true;
-    } else if (ch === '{') {
-      depth++;
-    } else if (ch === '}') {
-      depth--;
-      if (depth === 0) {
-        return stripped.slice(start, i + 1);
-      }
-    }
-  }
-  return stripped.slice(start).trim();
-}
 
 /** Split a unified diff into per-file hunks and drop files matching ignore patterns. */
 export function filterDiff(diff: string, ignore: string[]): string {
@@ -166,15 +102,10 @@ export async function judgeDiff(
 
   const prompt = buildPrompt(framework, filteredDiff, threshold, specs);
   const raw = await callLLM(config, prompt);
-  const response = extractJsonObject(raw);
-
-  let parsed: { files?: Array<{ file: string; score?: number; reason?: string; gap?: string }>; threshold?: number };
-  try {
-    parsed = JSON.parse(response);
-  } catch (err) {
-    const parseMessage = err instanceof Error ? err.message : String(err);
-    throw new LlmJsonParseError(parseMessage, raw, config.model);
-  }
+  const parsed = parseLlmJson<{
+    files?: Array<{ file: string; score?: number; reason?: string; gap?: string }>;
+    threshold?: number;
+  }>(raw, config.model);
 
   const files = (parsed.files ?? []).map(f => ({
     file: f.file,

--- a/packages/corespec/src/tools/judge-diff.ts
+++ b/packages/corespec/src/tools/judge-diff.ts
@@ -3,6 +3,33 @@ import { callLLM } from '../llm/provider.js';
 import picomatch from 'picomatch';
 
 /**
+ * Thrown when the LLM returns a response that is not parseable JSON.
+ * Carries the raw response and model name so callers can surface actionable
+ * error messages instead of bare JSON.parse output.
+ */
+export class LlmJsonParseError extends Error {
+  public readonly rawResponse: string;
+  public readonly model: string;
+  public readonly parseError: string;
+
+  constructor(parseError: string, rawResponse: string, model: string) {
+    const preview = rawResponse.trim().slice(0, 200).replace(/\s+/g, ' ');
+    const suffix = rawResponse.length > 200 ? '…' : '';
+    super(
+      `LLM returned a non-JSON response (model: ${model}). ` +
+        `JSON parse error: ${parseError}. ` +
+        `Response preview: "${preview}${suffix}". ` +
+        `The model likely ignored the JSON-only instruction. Try a more capable model ` +
+        `(e.g. claude-sonnet-4) or reduce the prompt size by tightening the ignore list in .specguard.yml.`,
+    );
+    this.name = 'LlmJsonParseError';
+    this.rawResponse = rawResponse;
+    this.model = model;
+    this.parseError = parseError;
+  }
+}
+
+/**
  * Extracts the first balanced JSON object from an LLM response, tolerating
  * leading/trailing prose, markdown code fences, or commentary.
  */
@@ -141,7 +168,13 @@ export async function judgeDiff(
   const raw = await callLLM(config, prompt);
   const response = extractJsonObject(raw);
 
-  const parsed = JSON.parse(response) as { files?: Array<{ file: string; score?: number; reason?: string; gap?: string }>; threshold?: number };
+  let parsed: { files?: Array<{ file: string; score?: number; reason?: string; gap?: string }>; threshold?: number };
+  try {
+    parsed = JSON.parse(response);
+  } catch (err) {
+    const parseMessage = err instanceof Error ? err.message : String(err);
+    throw new LlmJsonParseError(parseMessage, raw, config.model);
+  }
 
   const files = (parsed.files ?? []).map(f => ({
     file: f.file,

--- a/packages/corespec/src/tools/judge-diff.ts
+++ b/packages/corespec/src/tools/judge-diff.ts
@@ -85,7 +85,9 @@ function buildPrompt(
     ? `\nExisting spec documents in the repository:\n${specs.map(s => `--- ${s.path} ---\n${s.content}`).join('\n\n')}\n`
     : '';
 
-  return `You are a spec coverage analysis tool. Given a git diff and information about the repository's spec framework, evaluate whether each changed file has adequate specification coverage.
+  return `You are a spec coverage analysis tool. Respond with ONLY a JSON object matching the schema below. Do not include any text, headings, markdown, or commentary outside the JSON object.
+
+Evaluation task: given a git diff and the repository's spec framework, score each changed file on how adequately specs cover its behavior.
 
 Framework context:
 ${frameworkContext}
@@ -104,7 +106,7 @@ Structural or wiring changes that don't alter behavior — such as re-exports in
 
 Test files (e.g. *.test.ts, *.spec.ts) are self-documenting and do not require separate specs. Score these 1.0 with reason "test file, self-documenting".
 
-Respond with ONLY a JSON object (no markdown, no code fences):
+Output format — respond with EXACTLY this JSON object, nothing before or after:
 {
   "files": [
     {
@@ -116,7 +118,9 @@ Respond with ONLY a JSON object (no markdown, no code fences):
   ],
   "result": "<'pass' if all files pass, 'fail' if any file fails>",
   "threshold": ${threshold}
-}`;
+}
+
+Begin your response with the opening brace '{'. Do not add any preamble.`;
 }
 
 export async function judgeDiff(

--- a/packages/corespec/src/tools/judge-diff.ts
+++ b/packages/corespec/src/tools/judge-diff.ts
@@ -2,6 +2,44 @@ import type { FrameworkJudgment, DiffJudgment, ModelConfig, SpecDocument } from 
 import { callLLM } from '../llm/provider.js';
 import picomatch from 'picomatch';
 
+/**
+ * Extracts the first balanced JSON object from an LLM response, tolerating
+ * leading/trailing prose, markdown code fences, or commentary.
+ */
+export function extractJsonObject(raw: string): string {
+  const stripped = raw.replace(/```(?:json)?\s*/g, '').replace(/\s*```/g, '');
+  const start = stripped.indexOf('{');
+  if (start === -1) return stripped.trim();
+
+  let depth = 0;
+  let inString = false;
+  let escape = false;
+  for (let i = start; i < stripped.length; i++) {
+    const ch = stripped[i];
+    if (inString) {
+      if (escape) {
+        escape = false;
+      } else if (ch === '\\') {
+        escape = true;
+      } else if (ch === '"') {
+        inString = false;
+      }
+      continue;
+    }
+    if (ch === '"') {
+      inString = true;
+    } else if (ch === '{') {
+      depth++;
+    } else if (ch === '}') {
+      depth--;
+      if (depth === 0) {
+        return stripped.slice(start, i + 1);
+      }
+    }
+  }
+  return stripped.slice(start).trim();
+}
+
 /** Split a unified diff into per-file hunks and drop files matching ignore patterns. */
 export function filterDiff(diff: string, ignore: string[]): string {
   if (ignore.length === 0) return diff;
@@ -97,7 +135,7 @@ export async function judgeDiff(
 
   const prompt = buildPrompt(framework, filteredDiff, threshold, specs);
   const raw = await callLLM(config, prompt);
-  const response = raw.replace(/^```(?:json)?\s*\n?/gm, '').replace(/\n?```\s*$/gm, '').trim();
+  const response = extractJsonObject(raw);
 
   const parsed = JSON.parse(response) as { files?: Array<{ file: string; score?: number; reason?: string; gap?: string }>; threshold?: number };
 

--- a/packages/corespec/src/tools/load-specs.ts
+++ b/packages/corespec/src/tools/load-specs.ts
@@ -1,0 +1,32 @@
+import { readdirSync, readFileSync, statSync, existsSync } from 'fs';
+import { join, relative } from 'path';
+import type { SpecDocument } from '../types.js';
+
+function walkMarkdown(root: string, dir: string, out: string[]): void {
+  for (const name of readdirSync(dir)) {
+    const full = join(dir, name);
+    const stat = statSync(full);
+    if (stat.isDirectory()) {
+      walkMarkdown(root, full, out);
+    } else if (name.endsWith('.md')) {
+      out.push(full);
+    }
+  }
+}
+
+/** Load spec documents for a given framework from the repository. */
+export function loadSpecs(repoRoot: string, framework: string): SpecDocument[] {
+  const specsDir = framework === 'openspec'
+    ? join(repoRoot, 'openspec', 'specs')
+    : null;
+
+  if (!specsDir || !existsSync(specsDir)) return [];
+
+  const paths: string[] = [];
+  walkMarkdown(repoRoot, specsDir, paths);
+
+  return paths.map(p => ({
+    path: relative(repoRoot, p),
+    content: readFileSync(p, 'utf-8'),
+  }));
+}

--- a/packages/corespec/src/types.ts
+++ b/packages/corespec/src/types.ts
@@ -34,8 +34,16 @@ export interface FileCoverage {
   score: number;
   /** Whether this file passes the threshold */
   pass: boolean;
-  /** Explanation of what spec coverage is missing, if any */
-  gap?: string;
+  /** One-line explanation of the score — describes coverage for passing files, gaps for failing files */
+  reason: string;
+}
+
+/** A spec document loaded from the repository, passed to judge-diff as context */
+export interface SpecDocument {
+  /** File path relative to repo root (e.g. "openspec/specs/hook-install/spec.md") */
+  path: string;
+  /** Full spec content */
+  content: string;
 }
 
 /** Output of judge-diff (LLM) */

--- a/packages/respec/package.json
+++ b/packages/respec/package.json
@@ -36,6 +36,8 @@
   "scripts": {
     "build": "tsc",
     "dev": "tsc --watch",
+    "prestart": "tsc",
+    "start": "node ./bin/respec.js",
     "test": "vitest run",
     "test:watch": "vitest"
   },

--- a/packages/specguard/action/comment.sh
+++ b/packages/specguard/action/comment.sh
@@ -13,13 +13,17 @@ fi
 HEAD_REF=$(jq -r '.pull_request.head.ref // empty' "$GITHUB_EVENT_PATH" 2>/dev/null || true)
 HEAD_REF="${HEAD_REF:-${GITHUB_REF_NAME:-main}}"
 
-# Maps a framework name to the repo directory holding its specs.
+# Maps a recognised spec framework to the repo directory holding its spec/plan
+# documents. Only frameworks with a known, verified convention are listed;
+# others render as plain text in the comment.
+#   OpenSpec:    https://github.com/Fission-AI/OpenSpec
+#   Kiro:        https://kiro.dev/docs/specs/
+#   Superpowers: https://github.com/obra/superpowers
 framework_spec_dir() {
   case "$1" in
     openspec) echo "openspec/specs" ;;
     kiro) echo ".kiro/specs" ;;
-    superpowers) echo ".claude/skills" ;;
-    generic) echo "specs" ;;
+    superpowers) echo "docs/superpowers/plans" ;;
     *) echo "" ;;
   esac
 }

--- a/packages/specguard/action/comment.sh
+++ b/packages/specguard/action/comment.sh
@@ -9,12 +9,41 @@ if [ -z "$PR_NUMBER" ]; then
   exit 0
 fi
 
+# Resolve head ref (branch name) from the PR event; fall back to GITHUB_REF_NAME.
+HEAD_REF=$(jq -r '.pull_request.head.ref // empty' "$GITHUB_EVENT_PATH" 2>/dev/null || true)
+HEAD_REF="${HEAD_REF:-${GITHUB_REF_NAME:-main}}"
+
+# Maps a framework name to the repo directory holding its specs.
+framework_spec_dir() {
+  case "$1" in
+    openspec) echo "openspec/specs" ;;
+    kiro) echo ".kiro/specs" ;;
+    superpowers) echo ".claude/skills" ;;
+    generic) echo "specs" ;;
+    *) echo "" ;;
+  esac
+}
+
+# Render a framework name as a markdown hyperlink to its spec directory on the PR head ref,
+# so reviewers can click through to the canonical spec sources.
+render_framework_link() {
+  local framework="$1"
+  local dir
+  dir=$(framework_spec_dir "$framework")
+  if [ -z "$dir" ] || [ "$framework" = "none" ]; then
+    echo "$framework"
+    return
+  fi
+  echo "[${framework}](https://github.com/${GITHUB_REPOSITORY}/tree/${HEAD_REF}/${dir})"
+}
+
 # Try to parse JSON result
 if echo "$RESULT_JSON" | jq . >/dev/null 2>&1; then
   RESULT=$(echo "$RESULT_JSON" | jq -r '.result')
   THRESHOLD=$(echo "$RESULT_JSON" | jq -r '.threshold')
   FRAMEWORK=$(echo "$RESULT_JSON" | jq -r '.framework.detected')
   CONFIDENCE=$(echo "$RESULT_JSON" | jq -r '.framework.confidence')
+  FRAMEWORK_LINK=$(render_framework_link "$FRAMEWORK")
 
   if [ "$RESULT" = "pass" ]; then
     ICON="white_check_mark"
@@ -24,26 +53,28 @@ if echo "$RESULT_JSON" | jq . >/dev/null 2>&1; then
     TITLE="specguard: FAIL"
   fi
 
-  # Build coverage table
-  COVERAGE_TABLE="| File | Score | Status | Gap |
-|------|-------|--------|-----|"
+  # Build coverage table. Every row includes a Reason so passing items explain why
+  # (e.g. "covered by hook-install spec", "test file, self-documenting").
+  COVERAGE_TABLE="| File | Score | Status | Reason |
+|------|-------|--------|--------|"
   while IFS= read -r row; do
     FILE=$(echo "$row" | jq -r '.file')
     SCORE=$(echo "$row" | jq -r '.score')
     PASS=$(echo "$row" | jq -r '.pass')
-    GAP=$(echo "$row" | jq -r '.gap // "-"')
+    # Fall back to legacy "gap" field for backwards compatibility with older payloads.
+    REASON=$(echo "$row" | jq -r '.reason // .gap // "-"')
     if [ "$PASS" = "true" ]; then
       STATUS=":white_check_mark:"
     else
       STATUS=":x:"
     fi
     COVERAGE_TABLE="$COVERAGE_TABLE
-| \`$FILE\` | $SCORE | $STATUS | $GAP |"
+| \`$FILE\` | $SCORE | $STATUS | $REASON |"
   done < <(echo "$RESULT_JSON" | jq -c '.coverage[]')
 
   BODY=":${ICON}: **${TITLE}**
 
-**Framework:** ${FRAMEWORK} (confidence: ${CONFIDENCE})
+**Framework:** ${FRAMEWORK_LINK} (confidence: ${CONFIDENCE})
 **Threshold:** ${THRESHOLD}
 
 ${COVERAGE_TABLE}"

--- a/packages/specguard/package.json
+++ b/packages/specguard/package.json
@@ -37,6 +37,8 @@
   "scripts": {
     "build": "tsc",
     "dev": "tsc --watch",
+    "prestart": "tsc",
+    "start": "node ./bin/specguard.js",
     "test": "vitest run",
     "test:watch": "vitest"
   },

--- a/packages/specguard/src/cli/cli.test.ts
+++ b/packages/specguard/src/cli/cli.test.ts
@@ -37,4 +37,20 @@ describe('specguard CLI', () => {
     expect(output).toContain('--model');
     expect(output).toContain('--output');
   });
+
+  it('shows hook command in help', () => {
+    const output = execFileSync('node', [bin, '--help'], {
+      encoding: 'utf-8',
+    });
+    expect(output).toContain('hook');
+  });
+
+  it('shows hook install subcommand help', () => {
+    const output = execFileSync('node', [bin, 'hook', 'install', '--help'], {
+      encoding: 'utf-8',
+    });
+    expect(output).toContain('pre-push');
+    expect(output).toContain('--pre-commit');
+    expect(output).toContain('--force');
+  });
 });

--- a/packages/specguard/src/cli/commands/check.ts
+++ b/packages/specguard/src/cli/commands/check.ts
@@ -1,6 +1,6 @@
 import { Command } from 'commander';
 import { execSync } from 'child_process';
-import { APICallError } from '@getcorespec/corespec';
+import { APICallError, LlmJsonParseError } from '@getcorespec/corespec';
 import { loadConfig } from '../../core/config.js';
 import { runPipeline } from '../../core/pipeline.js';
 import { formatHuman, formatJson } from '../../core/formatter.js';
@@ -54,6 +54,8 @@ export const checkCommand = new Command('check')
     } catch (err: unknown) {
       if (APICallError.isInstance(err) && err.statusCode === 401) {
         console.error('Error: invalid or missing API key. Set ANTHROPIC_API_KEY or OPENAI_API_KEY.');
+      } else if (err instanceof LlmJsonParseError) {
+        console.error(`Error: ${err.message}`);
       } else {
         console.error(`Error: LLM call failed — ${err instanceof Error ? err.message : String(err)}`);
       }

--- a/packages/specguard/src/cli/commands/hook.ts
+++ b/packages/specguard/src/cli/commands/hook.ts
@@ -3,13 +3,34 @@ import { existsSync, writeFileSync, mkdirSync } from 'fs';
 import { join } from 'path';
 import { execSync } from 'child_process';
 
-const HOOK_SCRIPT = `#!/bin/sh
+const PRE_PUSH_HOOK_SCRIPT = `#!/bin/sh
+# specguard pre-push hook
+# Checks spec coverage for all commits being pushed
+z40="0000000000000000000000000000000000000000"
+while IFS=' ' read local_ref local_sha remote_ref remote_sha; do
+  [ "$local_sha" = "$z40" ] && continue
+  if [ "$remote_sha" = "$z40" ]; then
+    base=$(git merge-base HEAD origin/main 2>/dev/null || \\
+           git merge-base HEAD origin/master 2>/dev/null || \\
+           git rev-list --max-parents=0 HEAD)
+    range="\${base}..\${local_sha}"
+  else
+    range="\${remote_sha}..\${local_sha}"
+  fi
+  npx specguard check "$range" || exit 1
+done
+`;
+
+const PRE_COMMIT_HOOK_SCRIPT = `#!/bin/sh
+# specguard pre-commit hook
+# Checks spec coverage for staged changes
 npx specguard check --staged
 `;
 
 const installHookCommand = new Command('install')
-  .description('Install specguard as a git pre-commit hook')
-  .option('--force', 'overwrite existing pre-commit hook')
+  .description('Install specguard as a git hook (pre-push by default)')
+  .option('--force', 'overwrite existing hook')
+  .option('--pre-commit', 'install as a pre-commit hook instead of pre-push')
   .action((options) => {
     let repoRoot: string;
     try {
@@ -20,7 +41,9 @@ const installHookCommand = new Command('install')
     }
 
     const hooksDir = join(repoRoot, '.git', 'hooks');
-    const hookPath = join(hooksDir, 'pre-commit');
+    const hookType = options.preCommit ? 'pre-commit' : 'pre-push';
+    const hookPath = join(hooksDir, hookType);
+    const hookScript = options.preCommit ? PRE_COMMIT_HOOK_SCRIPT : PRE_PUSH_HOOK_SCRIPT;
 
     if (!existsSync(hooksDir)) {
       mkdirSync(hooksDir, { recursive: true });
@@ -33,9 +56,14 @@ const installHookCommand = new Command('install')
       process.exit(1);
     }
 
-    writeFileSync(hookPath, HOOK_SCRIPT, { mode: 0o755 });
-    console.log(`Installed pre-commit hook at ${hookPath}`);
-    console.log('specguard will now check staged changes before each commit.');
+    writeFileSync(hookPath, hookScript, { mode: 0o755 });
+    if (options.preCommit) {
+      console.log(`Installed pre-commit hook at ${hookPath}`);
+      console.log('specguard will now check staged changes before each commit.');
+    } else {
+      console.log(`Installed pre-push hook at ${hookPath}`);
+      console.log('specguard will now check spec coverage before each push.');
+    }
   });
 
 export const hookCommand = new Command('hook')

--- a/packages/specguard/src/cli/index.ts
+++ b/packages/specguard/src/cli/index.ts
@@ -6,6 +6,15 @@ import { hookCommand } from './commands/hook.js';
 const require = createRequire(import.meta.url);
 const { version } = require('../../package.json');
 
+// Set the terminal title to the invoked command (e.g. "specguard check") so
+// terminal screenshots show exactly what's running. Skipped when not a TTY
+// (CI logs, piped output) to avoid polluting captured output.
+if (process.stdout.isTTY) {
+  const subcommand = process.argv.slice(2).find((a) => !a.startsWith('-'));
+  const title = subcommand ? `specguard ${subcommand}` : 'specguard';
+  process.stdout.write(`\x1b]2;${title}\x07`);
+}
+
 const program = new Command();
 
 program

--- a/packages/specguard/src/core/formatter.test.ts
+++ b/packages/specguard/src/core/formatter.test.ts
@@ -10,8 +10,8 @@ const sampleResult: PipelineResult = {
   },
   diff: {
     files: [
-      { file: 'src/auth/login.ts', score: 0.85, pass: true },
-      { file: 'src/auth/middleware.ts', score: 0.2, pass: false, gap: 'no spec covers auth middleware' },
+      { file: 'src/auth/login.ts', score: 0.85, pass: true, reason: 'covered by auth spec' },
+      { file: 'src/auth/middleware.ts', score: 0.2, pass: false, reason: 'no spec covers auth middleware' },
     ],
     result: 'fail',
     threshold: 0.7,

--- a/packages/specguard/src/core/formatter.ts
+++ b/packages/specguard/src/core/formatter.ts
@@ -12,7 +12,7 @@ export function formatJson(result: PipelineResult): string {
       file: f.file,
       score: f.score,
       pass: f.pass,
-      ...(f.gap ? { gap: f.gap } : {}),
+      reason: f.reason,
     })),
     result: result.diff.result,
     threshold: result.diff.threshold,
@@ -44,8 +44,8 @@ export function formatHuman(result: PipelineResult): string {
     const icon = file.pass ? chalk.green('\u2713') : chalk.red('\u2717');
     const name = file.file.length > 40 ? '\u2026' + file.file.slice(-39) : file.file;
     lines.push(`  ${name.padEnd(41)} ${score}  ${icon}`);
-    if (file.gap) {
-      lines.push(chalk.dim(`    ${file.gap}`));
+    if (file.reason) {
+      lines.push(chalk.dim(`    ${file.reason}`));
     }
   }
 

--- a/packages/specguard/src/core/pipeline.test.ts
+++ b/packages/specguard/src/core/pipeline.test.ts
@@ -4,14 +4,16 @@ vi.mock('@getcorespec/corespec', () => ({
   checkFramework: vi.fn(),
   judgeFramework: vi.fn(),
   judgeDiff: vi.fn(),
+  loadSpecs: vi.fn(() => []),
 }));
 
 import { runPipeline } from './pipeline.js';
-import { checkFramework, judgeFramework, judgeDiff } from '@getcorespec/corespec';
+import { checkFramework, judgeFramework, judgeDiff, loadSpecs } from '@getcorespec/corespec';
 
 const mockCheckFramework = vi.mocked(checkFramework);
 const mockJudgeFramework = vi.mocked(judgeFramework);
 const mockJudgeDiff = vi.mocked(judgeDiff);
+const mockLoadSpecs = vi.mocked(loadSpecs);
 
 describe('runPipeline', () => {
   beforeEach(() => {
@@ -31,10 +33,14 @@ describe('runPipeline', () => {
     });
 
     mockJudgeDiff.mockResolvedValue({
-      files: [{ file: 'src/index.ts', score: 0.9, pass: true }],
+      files: [{ file: 'src/index.ts', score: 0.9, pass: true, reason: 'covered by index spec' }],
       result: 'pass',
       threshold: 0.7,
     });
+
+    mockLoadSpecs.mockReturnValue([
+      { path: 'openspec/specs/index/spec.md', content: '# Index spec' },
+    ]);
 
     const result = await runPipeline({
       repoRoot: '/tmp/test-repo',
@@ -45,7 +51,13 @@ describe('runPipeline', () => {
 
     expect(mockCheckFramework).toHaveBeenCalledWith('/tmp/test-repo');
     expect(mockJudgeFramework).toHaveBeenCalled();
+    expect(mockLoadSpecs).toHaveBeenCalledWith('/tmp/test-repo', 'openspec');
     expect(mockJudgeDiff).toHaveBeenCalled();
+    // Verify specs were threaded through to judge-diff so the LLM sees them.
+    const judgeDiffCall = mockJudgeDiff.mock.calls[0];
+    expect(judgeDiffCall[5]).toEqual([
+      { path: 'openspec/specs/index/spec.md', content: '# Index spec' },
+    ]);
     expect(result.framework.framework).toBe('openspec');
     expect(result.diff.result).toBe('pass');
   });

--- a/packages/specguard/src/core/pipeline.ts
+++ b/packages/specguard/src/core/pipeline.ts
@@ -2,6 +2,7 @@ import {
   checkFramework,
   judgeFramework,
   judgeDiff,
+  loadSpecs,
   type FrameworkCheckResult,
   type FrameworkJudgment,
   type DiffJudgment,
@@ -29,7 +30,9 @@ export async function runPipeline(options: PipelineOptions): Promise<PipelineRes
 
   const framework = await judgeFramework(signals, modelConfig);
 
-  const diff = await judgeDiff(framework, options.diff, modelConfig, options.threshold, options.ignore);
+  const specs = loadSpecs(options.repoRoot, framework.framework);
+
+  const diff = await judgeDiff(framework, options.diff, modelConfig, options.threshold, options.ignore, specs);
 
   return { signals, framework, diff };
 }


### PR DESCRIPTION
## Summary

**Pre-push hook (closes #20)**
- `specguard hook install` writes a pre-push hook by default; `--pre-commit` is opt-in
- Pre-push script parses git's stdin ref protocol and handles new/deleted branches

**Specguard reporting**
- LLM now sees existing OpenSpec specs as context when judging coverage (fixes the case where the spec itself is filtered by `*.md` from the diff)
- `FileCoverage.gap` → `FileCoverage.reason`: every row in the PR comment — pass or fail — carries a one-line explanation (e.g. "covered by hook-install spec", "test file, self-documenting")
- Framework name rendered as a markdown hyperlink to the spec directory on the PR head ref (`[openspec](…/openspec/specs)`)
- `LlmJsonParseError` replaces bare `JSON.parse` errors — surfaces the model, a response preview, and remediation guidance
- Robust JSON extractor tolerates trailing prose / markdown fences around LLM output

**Developer ergonomics**
- `pnpm start <args>` one-shot build+run for specguard and respec
- CLI sets terminal title to `specguard <subcommand>` on TTY so screenshots are self-labelling
- CLAUDE.md documents the dev-run workflow and the pnpm `--` quirk

**Specs**
- `openspec/specs/hook-install/spec.md` (new) — hook install behaviour
- `openspec/specs/diff-filtering/spec.md` — now covers spec-as-context, reason field, test-file exemption, non-JSON error handling
- `openspec/specs/pr-comment/spec.md` (new) — framework hyperlink and reason column